### PR TITLE
mikkelblyme:manifest-v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "version": "1.0",
   "name": "Copy Jira task id",
   "description": "Simple extension that copies the current jira task id",
@@ -8,7 +8,7 @@
     "48": "images/puppy48.png",
     "128": "images/puppy.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "images/puppy.png",
     "default_popup": "popup.html"
   },
@@ -16,4 +16,3 @@
     "activeTab"
   ]
 }
-


### PR DESCRIPTION
When installed, an error is thrown in `brave(chrome)://extensions` due to version 2 of the manifest.
This raise the manifest version and refactors to satisfy those
requirements. I haven't checked all differences in the two versions, but these changes works and no errors were thrown for me

See https://developer.chrome.com/blog/mv2-transition/ and https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/
